### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "browser"
   ],
   "dependencies": {
-    "sexylog": "0.0.3",
     "muon-core": "7.1.7",
-    "underscore": "*",
-    "node-uuid": "*",
+    "rsvp": "*",
+    "sexylog": "0.0.3",
     "sockjs": "*",
     "sockjs-client": "*",
-    "rsvp": "*"
+    "underscore": "*",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "minifier": "*",
@@ -40,7 +40,7 @@
     "babel-core": "^6.4.5",
     "mocha": "*",
     "browserify": "*",
-    "loose-envify":"*",
+    "loose-envify": "*",
     "json-markup": "1.0.0",
     "jquery": "3.1.0"
   },

--- a/src/ws/transport.js
+++ b/src/ws/transport.js
@@ -1,6 +1,6 @@
 var _ = require("underscore");
 var bichannel = require('muon-core').channel();
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 
 var SockJS = require("sockjs-client")
 var MuonSocketAgent = require("muon-core").MuonSocketAgent


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.